### PR TITLE
Add rsan::license_uuid function with rspec test

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,4 +3,4 @@
 ---
 fixtures:
   forge_modules:
-#     stdlib: "puppetlabs/stdlib"
+    stdlib: "puppetlabs/stdlib"

--- a/functions/license_uuid.pp
+++ b/functions/license_uuid.pp
@@ -1,0 +1,12 @@
+# return the uuid from a Puppet license file supplied in $content
+# If no $content parameter specified, tries to read the license file
+# from /etc/puppetlabs/license.key
+function rsan::license_uuid(Optional[String] $content) >> String {
+  $license_file_path = '/etc/puppetlabs/license.key'
+  if $content {
+    $_content = parseyaml($content)
+  } else {
+    $_content = load_yaml($license_file_path)
+  }
+  return $_content['uuid']
+}

--- a/metadata.json
+++ b/metadata.json
@@ -23,6 +23,10 @@
     {
       "name": "derdanne/nfs",
       "version_requirement": ">= 2.1.5 < 3.0.0"
+    },
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 6.5.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/functions/license_uuid_spec.rb
+++ b/spec/functions/license_uuid_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+# let's define a typical license content string here
+
+license = <<-LICENSE
+  #######################
+  # Begin License File #
+  #######################
+  # PUPPET ENTERPRISE LICENSE - Puppet Labs
+  uuid: f13f0fe69ad3bf67e842c8473afaf12913e14516
+  to: "Puppet Labs"
+  nodes: 5000
+  end: 2030-08-04
+  #####################
+  # End License File #
+  #####################
+LICENSE
+
+describe 'rsan::license_uuid' do
+  it { is_expected.to run.with_params(license).and_return('f13f0fe69ad3bf67e842c8473afaf12913e14516') }
+end


### PR DESCRIPTION
This PR adds a function `rsan::license_uuid` along with a rspec test.

To run the test, do
```bash
pdk bundle exec rspec spec/functions/license_uuid_spec.rb
```

For the `parseyaml` funcion, added `stdlib` module as dependency.
