### PR TITLE
(#21) Handle multiple rsan IPs and Undef

### DIFF
--- a/functions/get_rsan_importer_ips.pp
+++ b/functions/get_rsan_importer_ips.pp
@@ -1,6 +1,7 @@
-function rsan::get_rsan_ip() {
+# @return [Array] List of IP addresses for RSAN nodes or an empty array
+function rsan::get_rsan_importer_ips() {
   if $settings::storeconfigs {
-    $rsan_ip =
+    $rsan_importer_ips =
       puppetdb_query('facts[value]{
         name = "ipaddress" and
         certname in resources[certname] {
@@ -13,6 +14,6 @@ function rsan::get_rsan_ip() {
           }
         }').map |$data| { $data['value'] }
   } else {
-    $rsan_ip = []
+    $rsan_importer_ips = []
   }
 }

--- a/functions/get_rsan_ip.pp
+++ b/functions/get_rsan_ip.pp
@@ -11,8 +11,8 @@ function rsan::get_rsan_ip() {
             expired is null
             }
           }
-        }')[0][value]
+        }').map |$data| { $data['value'] }
   } else {
-    $rsan_ip = Undef
+    $rsan_ip = []
   }
 }

--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -1,14 +1,18 @@
 #
 # When Applied to the Infrastruture Agent Node group, 
 #Will dynamically configure all matching nodes to allow access to key elements of Puppet Enterprise to the RSAN node
+# @param [Array] rsan_ip_list
+#   An array of rsan ip addresses
+#   Defaults to the output of a PuppetDB query
+# @param [String] rsan_host
+#   The certname of the rsan node
 # 
 # @example
 #   include rsan::exporter
 
 class rsan::exporter (
-  $rsan_host = undef,
-  Array $rsanip = rsan::get_rsan_ip(),
-
+  Array $rsan_importer_ips = rsan::rsan_importer_ips(),
+  Optional[String] $rsan_host = undef,
 ){
 
 ########################1.  Export Logging Function######################
@@ -19,7 +23,13 @@ class rsan::exporter (
     server_enabled => true
   }
 
-  $_rsan_clients = $rsanip.reduce('') |$memo, $ip| {
+# Convert the array of RSAN IP address into an list of clients with options for the NFS export.
+# This reduce will return a string of space deliminated IP addresses with the NFS options.
+# For example, the output for ['1.2.3.4'] is " 1.2.3.4(ro,insecure,async,no_root_squash)"
+# For example, the output for ['1.2.3.4', '5.6.7.8'] is 
+#   " 1.2.3.4(ro,insecure,async,no_root_squash) 5.6.7.8(ro,insecure,async,no_root_squash)"
+
+  $_rsan_clients = $rsan_importer_ips.reduce('') |$memo, $ip| {
     "${memo} ${ip}(ro,insecure,async,no_root_squash)"
   }
   $clients = "${_rsan_clients} localhost(ro)"

--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -7,7 +7,7 @@
 
 class rsan::exporter (
   $rsan_host = undef,
-  String $rsanip = rsan::get_rsan_ip(),
+  Array $rsanip = rsan::get_rsan_ip(),
 
 ){
 
@@ -19,21 +19,26 @@ class rsan::exporter (
     server_enabled => true
   }
 
+  $_rsan_clients = $rsanip.reduce('') |$memo, $ip| {
+    "${memo} ${ip}(ro,insecure,async,no_root_squash)"
+  }
+  $clients = "${_rsan_clients} localhost(ro)"
+
   nfs::server::export{ '/var/log/':
     ensure  => 'mounted',
-    clients => "${rsanip}(ro,insecure,async,no_root_squash) localhost(ro)",
+    clients => $clients,
     mount   => "/var/pesupport/${facts['fqdn']}/log",
   #  nfstag  => rsan,
   }
   nfs::server::export{ '/opt/puppetlabs/':
     ensure  => 'mounted',
-    clients => "${rsanip}(ro,insecure,async,no_root_squash) localhost(ro)",
+    clients => $clients,
     mount   => "/var/pesupport/${facts['fqdn']}/opt",
   #  nfstag  => rsan,
   }
   nfs::server::export{ '/etc/puppetlabs/':
     ensure  => 'mounted',
-    clients => "${rsanip}(ro,insecure,async,no_root_squash) localhost(ro)",
+    clients => $clients,
     mount   => "/var/pesupport/${facts['fqdn']}/etc",
   #  nfstag  => rsan,
   }


### PR DESCRIPTION
Prior to this commit, when the RSAN IP was empty or had multiple entries
in the PuppetDB query, the catalog would fail to compile. This commit
allows for empty and multiple returned items from the PuppetDB query.

Resolves #21 