### PR TITLE
(18) Add tags for NFS exports and collectors

### DIFF
--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -23,19 +23,19 @@ class rsan::exporter (
     ensure  => 'mounted',
     clients => "${rsanip}(ro,insecure,async,no_root_squash) localhost(ro)",
     mount   => "/var/pesupport/${facts['fqdn']}/log",
-  #  nfstag  => rsan,
+    nfstag  => rsan,
   }
   nfs::server::export{ '/opt/puppetlabs/':
     ensure  => 'mounted',
     clients => "${rsanip}(ro,insecure,async,no_root_squash) localhost(ro)",
     mount   => "/var/pesupport/${facts['fqdn']}/opt",
-  #  nfstag  => rsan,
+    nfstag  => rsan,
   }
   nfs::server::export{ '/etc/puppetlabs/':
     ensure  => 'mounted',
     clients => "${rsanip}(ro,insecure,async,no_root_squash) localhost(ro)",
     mount   => "/var/pesupport/${facts['fqdn']}/etc",
-  #  nfstag  => rsan,
+    nfstag  => rsan,
   }
 
 

--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -23,19 +23,19 @@ class rsan::exporter (
     ensure  => 'mounted',
     clients => "${rsanip}(ro,insecure,async,no_root_squash) localhost(ro)",
     mount   => "/var/pesupport/${facts['fqdn']}/log",
-    nfstag  => rsan,
+    nfstag  => 'rsan',
   }
   nfs::server::export{ '/opt/puppetlabs/':
     ensure  => 'mounted',
     clients => "${rsanip}(ro,insecure,async,no_root_squash) localhost(ro)",
     mount   => "/var/pesupport/${facts['fqdn']}/opt",
-    nfstag  => rsan,
+    nfstag  => 'rsan',
   }
   nfs::server::export{ '/etc/puppetlabs/':
     ensure  => 'mounted',
     clients => "${rsanip}(ro,insecure,async,no_root_squash) localhost(ro)",
     mount   => "/var/pesupport/${facts['fqdn']}/etc",
-    nfstag  => rsan,
+    nfstag  => 'rsan',
   }
 
 

--- a/manifests/importer.pp
+++ b/manifests/importer.pp
@@ -11,7 +11,7 @@ class rsan::importer {
   class { '::nfs':
     client_enabled => true,
   }
-  Nfs::Client::Mount <<| |>>
+  Nfs::Client::Mount <<| nfstag == 'rsan' |>>
 
 
   #################### 2. Deploy Client tools, and deploy PSL client #################


### PR DESCRIPTION
Prior to this commit, the collectors would import all of the exported
NFS mounts. This commit adds some nfs tags to ensure the collection is
only for the exports in this module.

Resolves #18 