### PR TITLE
Fix an incorrect function name in the exporter

### DIFF
--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -11,7 +11,7 @@
 #   include rsan::exporter
 
 class rsan::exporter (
-  Array $rsan_importer_ips = rsan::rsan_importer_ips(),
+  Array $rsan_importer_ips = rsan::get_rsan_importer_ips(),
   Optional[String] $rsan_host = undef,
 ){
 


### PR DESCRIPTION
Previously there was an incorrect function name when calling
get_rsan_importer_ips. This commit fixes that incorrect name.