### PR TITLE
This PR includes necessary modifications to make the compilation tests pass

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,3 +4,17 @@
 fixtures:
   forge_modules:
     stdlib: "puppetlabs/stdlib"
+    concat: "puppetlabs/concat"
+    postgresql: "puppetlabs/postgresql"
+    puppetdb: "puppetlabs/puppetdb"
+    puppet_metrics_dashboard: "puppetlabs/puppet_metrics_dashboard"
+    puppet_metrics_collector: "puppetlabs/puppet_metrics_collector"
+    nfs: "derdanne/nfs"
+    yumrepo: "puppetlabs/yumrepo_core"
+    grafana: "puppet/grafana"
+    telegraf: "puppet/telegraf"
+  repositories:
+    puppet-enterprise-modules: 'git@github.com:puppetlabs/puppet-enterprise-modules.git'
+  symlinks:
+    puppet_enterprise: "#{source_dir}/spec/fixtures/modules/puppet-enterprise-modules/modules/puppet_enterprise"
+    pe_hocon: "#{source_dir}/spec/fixtures/modules/puppet-enterprise-modules/modules/pe_hocon"

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,4 @@
+  Gemfile:
+    required:
+      ':development':
+        - gem: 'toml-rb'

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :development do
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "toml-rb",                                                 require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/spec/classes/exporter_spec.rb
+++ b/spec/classes/exporter_spec.rb
@@ -6,6 +6,7 @@ describe 'rsan::exporter' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
+      let(:pre_condition) { 'service {"puppetserver": }' }
 
       it { is_expected.to compile }
     end

--- a/spec/classes/importer_spec.rb
+++ b/spec/classes/importer_spec.rb
@@ -3,10 +3,14 @@
 require 'spec_helper'
 
 describe 'rsan::importer' do
+  before :each do
+    Puppet::Parser::Functions.newfunction(:puppetdb_query, :type => :rvalue, :arity => 1) do |args|
+      []
+    end  
+  end
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-
       it { is_expected.to compile }
     end
   end

--- a/spec/fixtures/data/common.yaml
+++ b/spec/fixtures/data/common.yaml
@@ -1,0 +1,4 @@
+---
+"puppet_enterprise::puppet_master_host": master.rspec
+"puppet_enterprise::manage_symlinks": false
+"puppet_enterprise::repo::config::platform_tag": el-7-x86_64

--- a/spec/fixtures/hiera.yaml
+++ b/spec/fixtures/hiera.yaml
@@ -1,0 +1,10 @@
+---
+version: 5
+
+defaults:  # Used for any hierarchy level that omits these keys.
+  datadir: data         # This path is relative to hiera.yaml's directory.
+  data_hash: yaml_data  # Use the built-in YAML backend.
+
+hierarchy:
+  - name: 'common'
+    path: 'common.yaml'

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,0 +1,4 @@
+RSpec.configure do |c|
+  c.hiera_config = File.expand_path(File.join(__dir__, 'fixtures/hiera.yaml'))
+  puts c.hiera_config
+end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,4 +1,3 @@
 RSpec.configure do |c|
   c.hiera_config = File.expand_path(File.join(__dir__, 'fixtures/hiera.yaml'))
-  puts c.hiera_config
 end


### PR DESCRIPTION
Note: because the `rsan::importer` and `rsan::exporter` rely on classes inside the `puppet_enterprise` module, there is a lot of context to set right before the compilation tests pass.

- add dependent modules to `.fixtures.yml`
- introduce hiera fixtures for setting required class parameters (introduce `spec_helper_local.rb` to that end)
- add `toml-rb` gem to Gemfile through `.sync.yml`
- stub `puppetdb_query` function in `rsan::importer` spec test
- mock `service {"puppetserver": }` in `rsan::exporter` spec test