### PR TITLE
(maint) Stub out puppet_enterprise in spec tests and add Spec testing CI

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,8 +13,4 @@ fixtures:
     yumrepo: "puppetlabs/yumrepo_core"
     grafana: "puppet/grafana"
     telegraf: "puppet/telegraf"
-  repositories:
-    puppet-enterprise-modules: 'git@github.com:puppetlabs/puppet-enterprise-modules.git'
-  symlinks:
-    puppet_enterprise: "#{source_dir}/spec/fixtures/modules/puppet-enterprise-modules/modules/puppet_enterprise"
-    pe_hocon: "#{source_dir}/spec/fixtures/modules/puppet-enterprise-modules/modules/pe_hocon"
+    puppetserver_gem: "puppetlabs/puppetserver_gem"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,19 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
- 
+
       - name: action-pdk-validate
   # You may pin to the exact commit or the version.
   # uses: puppets-epic-show-theatre/action-pdk-validate@31b5407676af16b690b2b8c54c0767af72fcc34f
         uses: puppets-epic-show-theatre/action-pdk-validate@v1.0.0
+        with:
+    # A string indicating the Puppet version to validate against, such as "5.4.2" or "5.5".
+          puppet-version: # optional
+    # A string indicating the PE version to validate against, such as "2017.3.5" or "2018.1".
+          pe-version: # optional
+
+      - name: action-pdk-test-unit
+        uses: puppets-epic-show-theatre/action-pdk-test-unit@v1
         with:
     # A string indicating the Puppet version to validate against, such as "5.4.2" or "5.5".
           puppet-version: # optional

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           - puppet_ver: '~> 6'
             ruby_ver: 2.5
-          - puppet_ver: '7'
+          - puppet_ver: '~> 7'
             ruby_ver: 2.7
     steps:
       - name: Checkout Source
@@ -32,20 +32,11 @@ jobs:
 
       - name: Activate Ruby ${{ matrix.ruby_ver }}
         uses: ruby/setup-ruby@v1
+        env:
+          PUPPET_GEM_VERSION: ${{ matrix.puppet_ver }}
         with:
           ruby-version: ${{ matrix.ruby_ver }}
           bundler-cache: true
-
-      - name: Install gems
-        env:
-          PUPPET_GEM_VERSION: ${{ matrix.puppet_ver }}
-        run: |
-          gem install bundler
-          bundle config path vendor/gems
-          bundle config jobs 8
-          bundle config retry 3
-          bundle install
-          bundle clean
 
       - name: Print Bundler Environment
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,30 +15,52 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
+  spec:
+    name: "Spec Tests"
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - puppet_ver: '~> 6'
+            ruby_ver: 2.5
+          - puppet_ver: '7'
+            ruby_ver: 2.7
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - name: Checkout Source
+        uses: actions/checkout@v2
 
-      - name: action-pdk-validate
-  # You may pin to the exact commit or the version.
-  # uses: puppets-epic-show-theatre/action-pdk-validate@31b5407676af16b690b2b8c54c0767af72fcc34f
-        uses: puppets-epic-show-theatre/action-pdk-validate@v1.0.0
+      - name: Activate Ruby ${{ matrix.ruby_ver }}
+        uses: ruby/setup-ruby@v1
         with:
-    # A string indicating the Puppet version to validate against, such as "5.4.2" or "5.5".
-          puppet-version: # optional
-    # A string indicating the PE version to validate against, such as "2017.3.5" or "2018.1".
-          pe-version: # optional
+          ruby-version: ${{ matrix.ruby_ver }}
+          bundler-cache: true
 
-      - name: action-pdk-test-unit
-        uses: puppets-epic-show-theatre/action-pdk-test-unit@v1
-        with:
-    # A string indicating the Puppet version to validate against, such as "5.4.2" or "5.5".
-          puppet-version: # optional
-    # A string indicating the PE version to validate against, such as "2017.3.5" or "2018.1".
-          pe-version: # optional
+      - name: Install gems
+        env:
+          PUPPET_GEM_VERSION: ${{ matrix.puppet_ver }}
+        run: |
+          gem install bundler
+          bundle config path vendor/gems
+          bundle config jobs 8
+          bundle config retry 3
+          bundle install
+          bundle clean
+
+      - name: Print Bundler Environment
+        env:
+          PUPPET_GEM_VERSION: ${{ matrix.puppet_ver }}
+        run: |
+          bundle env
+
+      - name: Code Validation
+        env:
+          PUPPET_GEM_VERSION: ${{ matrix.puppet_ver }}
+        run: |
+          bundle exec rake check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint
+
+      - name: Parallel Spec Tests
+        env:
+          PUPPET_GEM_VERSION: ${{ matrix.puppet_ver }}
+        run: |
+          bundle exec rake parallel_spec

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,10 @@
-  Gemfile:
-    required:
-      ':development':
-        - gem: 'toml-rb'
+Gemfile:
+  required:
+    ':development':
+      - gem: 'toml-rb'
+spec/default_facts.yml:
+  extra_facts:
+    pe_server_version: 2019.8.4
+    pe_build: 2019.8.4
+spec/spec_helper.rb:
+  hiera_config_ruby: File.expand_path(File.join(__dir__, 'fixtures/hiera.yaml'))

--- a/spec/classes/exporter_spec.rb
+++ b/spec/classes/exporter_spec.rb
@@ -6,7 +6,7 @@ describe 'rsan::exporter' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:pre_condition) { 'service {"puppetserver": }' }
+      let(:pre_condition) { 'service {"pe-puppetserver": }' }
 
       it { is_expected.to compile }
     end

--- a/spec/classes/importer_spec.rb
+++ b/spec/classes/importer_spec.rb
@@ -6,11 +6,16 @@ describe 'rsan::importer' do
   before :each do
     Puppet::Parser::Functions.newfunction(:puppetdb_query, :type => :rvalue, :arity => 1) do |args|
       []
-    end  
+    end
+    Puppet::Parser::Functions.newfunction(:pe_sort, :type => :rvalue, :arity => 1) do |args|
+      []
+    end
   end
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
+      let(:pre_condition) { 'class puppet_enterprise::profile::controller {}' }
+
       it { is_expected.to compile }
     end
   end

--- a/spec/classes/importer_spec.rb
+++ b/spec/classes/importer_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 
 describe 'rsan::importer' do
   before :each do
-    Puppet::Parser::Functions.newfunction(:puppetdb_query, :type => :rvalue, :arity => 1) do |args|
+    Puppet::Parser::Functions.newfunction(:puppetdb_query, type: :rvalue, arity: 1) do |_args|
       []
     end
-    Puppet::Parser::Functions.newfunction(:pe_sort, :type => :rvalue, :arity => 1) do |args|
+    Puppet::Parser::Functions.newfunction(:pe_sort, type: :rvalue, arity: 1) do |_args|
       []
     end
   end

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -6,3 +6,6 @@ ipaddress: "172.16.254.254"
 ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
+pe_server_version: 2019.8.4
+pe_build: 2019.8.4
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,7 @@ end
 
 RSpec.configure do |c|
   c.default_facts = default_facts
+  c.hiera_config = File.expand_path(File.join(__dir__, 'fixtures/hiera.yaml'))
   c.before :each do
     # set to strictest setting for testing
     # by default Puppet runs at warning level

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,3 +1,0 @@
-RSpec.configure do |c|
-  c.hiera_config = File.expand_path(File.join(__dir__, 'fixtures/hiera.yaml'))
-end


### PR DESCRIPTION
Prior to this commit, the module used the real puppet_enterprise module
to do the spec testing. The puppet_enterprise module is a private git
repo, so external testing would not work without authorization. This
commit stubs out the puppet_enterprise module to get the spec tests
working without github authorization.

This PR does the following. 

* Changes github action workflow to use bundler
* Adds spec testing to the github action
* Stubs out the `puppet_enterprise::profile::controller` class
* Stubs out the `pe_sort` function
* Removes the `puppet-enterprise-modules` from the fixtures
* Adds the `puppetserver_gem` module to the fixtures
* Moves the hiera_config into the `.sync.yml`
* Adds default facts so that the puppet metrics collector module uses the `pe-puppetserver` service