### PR TITLE
remove mocha deprecation warnings

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -9,3 +9,6 @@ spec/default_facts.yml:
   extra_facts:
     pe_server_version: 2019.8.4
     pe_build: 2019.8.4
+
+spec/spec_helper.rb:
+  mock_with: ":rspec"

--- a/.sync.yml
+++ b/.sync.yml
@@ -2,9 +2,10 @@ Gemfile:
   required:
     ':development':
       - gem: 'toml-rb'
+      - gem: rspec-puppet-facts
+        version: '>= 2.0.1'
+
 spec/default_facts.yml:
   extra_facts:
     pe_server_version: 2019.8.4
     pe_build: 2019.8.4
-spec/spec_helper.rb:
-  hiera_config_ruby: File.expand_path(File.join(__dir__, 'fixtures/hiera.yaml'))

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development do
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "toml-rb",                                                 require: false
+  gem "rspec-puppet-facts", '>= 2.0.1',                          require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,6 @@ end
 
 RSpec.configure do |c|
   c.default_facts = default_facts
-  c.hiera_config = File.expand_path(File.join(__dir__, 'fixtures/hiera.yaml'))
   c.before :each do
     # set to strictest setting for testing
     # by default Puppet runs at warning level


### PR DESCRIPTION
removes

Deprecation Warnings:

puppetlabs_spec_helper: defaults `mock_with` to `:mocha`. See https://github.com/puppetlabs/puppetlabs_spec_helper#mock_with to choose a sensible value for you
