### PR TITLE
(maint) Pin puppet-telegraf to 3.1.0 for spec tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,5 +12,7 @@ fixtures:
     nfs: "derdanne/nfs"
     yumrepo: "puppetlabs/yumrepo_core"
     grafana: "puppet/grafana"
-    telegraf: "puppet/telegraf"
+    telegraf:
+      repo: "puppet/telegraf"
+      ref: "3.1.0"
     puppetserver_gem: "puppetlabs/puppetserver_gem"


### PR DESCRIPTION
Prior to this commit, the spec tests were failing due to an issue in the
puppet-telegraf module. This commit pins the puppet-telegraf module to
version 3.1.0 to avoid the conflict.