### PR TITLE
Fix #46 (SUP-2384)

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -44,6 +44,9 @@ The following parameters are available in the `rsan::exporter` class:
 
 * [`rsan_importer_ips`](#rsan_importer_ips)
 * [`rsan_host`](#rsan_host)
+* [`pg_user`](#pg_user)
+* [`pg_group`](#pg_group)
+* [`pg_psql_path`](#pg_psql_path)
 
 ##### <a name="rsan_importer_ips"></a>`rsan_importer_ips`
 
@@ -61,6 +64,30 @@ Data type: `Optional[String]`
 The certname of the rsan node
 
 Default value: ``undef``
+
+##### <a name="pg_user"></a>`pg_user`
+
+Data type: `Optional[String]`
+
+The postgres user PE uses
+
+Default value: `'pe-postgres'`
+
+##### <a name="pg_group"></a>`pg_group`
+
+Data type: `Optional[String]`
+
+The postgres group PE uses the default is pg_user
+
+Default value: `$pg_user`
+
+##### <a name="pg_psql_path"></a>`pg_psql_path`
+
+Data type: `Optional[String]`
+
+The path to the postgres binary in pe
+
+Default value: `'/opt/puppetlabs/server/bin/psql'`
 
 ### <a name="rsanimporter"></a>`rsan::importer`
 

--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -17,7 +17,7 @@
 class rsan::exporter (
   Array $rsan_importer_ips = rsan::get_rsan_importer_ips(),
   Optional[String] $rsan_host = undef,
-  Optional[String] $pg_user =  'pe-postgres',
+  Optional[String] $pg_user = 'pe-postgres',
   Optional[String] $pg_group = $pg_user,
   Optional[String] $pg_psql_path = '/opt/puppetlabs/server/bin/psql',
 ){

--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -6,11 +6,20 @@
 #   Defaults to the output of a PuppetDB query
 # @param [Optional[String]] rsan_host
 #   The certname of the rsan node
+# @param [Optional[String]] pg_user
+#   The postgres user PE uses 
+# @param [Optional[String]] pg_group
+#   The postgres group PE uses the default is pg_user
+# @param [Optional[String]] pg_psql_path
+#   The path to the postgres binary in pe
 # @example
 #   include rsan::exporter
 class rsan::exporter (
   Array $rsan_importer_ips = rsan::get_rsan_importer_ips(),
   Optional[String] $rsan_host = undef,
+  Optional[String] $pg_user =  'pe-postgres',
+  Optional[String] $pg_group = $pg_user,
+  Optional[String] $pg_psql_path = '/opt/puppetlabs/server/bin/psql',
 ){
 
 ########################1.  Export Logging Function######################
@@ -116,12 +125,11 @@ class rsan::exporter (
           command    => $grant_cmd,
           db         => $db,
           port       => $pe_postgresql::server::port,
-          psql_user  => $puppet_enterprise::pg_user,
-          psql_group => $puppet_enterprise::pg_group,
-          psql_path  => $puppet_enterprise::pg_psql_path,
+          psql_user  => $pg_user,
+          psql_group => $pg_group,
+          psql_path  => $pg_psql_path,
           unless     => "SELECT grantee, privilege_type FROM information_schema.role_table_grants WHERE privilege_type = 'SELECT' AND grantee = 'rsan'",
           require    => [
-            Class['puppet_enterprise'],
             Class['pe_postgresql::server'],
             Pe_postgresql::Server::Role['rsan']
           ]

--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -116,11 +116,12 @@ class rsan::exporter (
           command    => $grant_cmd,
           db         => $db,
           port       => $pe_postgresql::server::port,
-          psql_user  => $pe_postgresql::server::user,
-          psql_group => $pe_postgresql::server::group,
-          psql_path  => $pe_postgresql::server::psql_path,
+          psql_user  => $puppet_enterprise::pg_user,
+          psql_group => $puppet_enterprise::pg_group,
+          psql_path  => $puppet_enterprise::pg_psql_path,
           unless     => "SELECT grantee, privilege_type FROM information_schema.role_table_grants WHERE privilege_type = 'SELECT' AND grantee = 'rsan'",
           require    => [
+            Class['puppet_enterprise'],
             Class['pe_postgresql::server'],
             Pe_postgresql::Server::Role['rsan']
           ]


### PR DESCRIPTION
https://github.com/puppetlabs/RSAN/issues/46

Prior to this commit on some deployments of the exporter class on a postgres node, resource ordering meant that default postgres users and groups where selected instead of the puppet_enterprise defaults