### PR TITLE
Fix for Issue 49 - New replica installation

### DIFF
--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -66,7 +66,9 @@ class rsan::exporter (
   # include puppet_metrics_dashboard::profile::master::install
   ###################################################################
 
-  include puppet_metrics_dashboard::profile::master::install
+  if $facts['pe_server_version'] != undef {
+    include puppet_metrics_dashboard::profile::master::install
+  }
 
   #####################3. RSANpostgres command access ######################
   # Determine if node is pe_postgres host and conditionally apply Select Access for the RSAN node cert to all PE databases


### PR DESCRIPTION
Prior to this commit, if a replica was added to the system after RSAN deployment, puppet runs would fail, as metrics dashboard would require puppetserver service to exist but due to pinning of the Replica to the infra agent group this was not always the case

this commit checks for a puppetserver fact before classifying these dashboard class