### PR TITLE
Make NFS mounts optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ The Puppet Enterprise Support team is opening an exciting Beta to help us remove
 The Remote Support Service Beta is a combination of a Service provided by the Support team and Puppet Module named RSAN (Remote Support Access Node).
 Puppet Enterprise Support will work with you to see how your organization can access the RSAN deployment and how that process should be implemented. , Currently we have two access options; direct as an incoming VPN connection from the Puppet Support Member, or a simple screen share on the video conferencing software of your choice.
 
-**How you can get involved**
+How you can get involved
 
-<br>
+
 As an existing Puppet Enterprise customer with access to the [Support Portal](http://support.puppet.com), open a Priority 4 ticket with the subject  “Participate in the RSAN beta” and a support engineer will engage with you regarding access methods and any help installing the module you may need.
 
 
@@ -123,6 +123,15 @@ Console Class Declaration
 ["1.2.3.4"]
 ```
 
+The RSAN::Exporter class allows for the NFS mounts to be optionally available, to disable existing mounts, or prevent the mounts from installing in the first place set the following parameter:
+
+
+In Hiera
+
+```
+rsan::exporter::nfsmount: false
+```
+
 ### PE Client tools
 
 The RSAN node will deploy Puppet Client tools for use by Puppet Enterprise on the RSAN platform, For More information please see the Puppet Enterprise Documentation:
@@ -171,6 +180,7 @@ Where valid options for <pe_db_name> are:
 ## Uninstallation 
 
 To Uninstall RSAN from your Puppet Enterprise Infrastructure.
+
 
  - Remove the following Classification:
 rsan::exporter\

--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -36,7 +36,11 @@ class rsan::exporter (
   }
 
 
-if $nfsmount {
+  $ensure = $nfsmount ? {
+    true  => 'mounted',
+    false => 'absent',
+  }
+
 
 # Convert the array of RSAN IP address into an list of clients with options for the NFS export.
 # This reduce will return a string of space deliminated IP addresses with the NFS options.
@@ -50,47 +54,27 @@ if $nfsmount {
   $clients = "${_rsan_clients} localhost(ro)"
 
   nfs::server::export{ '/var/log/':
-    ensure      => 'mounted',
+    ensure      => $ensure,
     clients     => $clients,
     mount       => "/var/pesupport/${facts['fqdn']}/log",
     options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
     nfstag      => 'rsan',
   }
   nfs::server::export{ '/opt/puppetlabs/':
-    ensure      => 'mounted',
+    ensure      => $ensure,
     clients     => $clients,
     mount       => "/var/pesupport/${facts['fqdn']}/opt",
     options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
     nfstag      => 'rsan',
   }
   nfs::server::export{ '/etc/puppetlabs/':
-    ensure      => 'mounted',
+    ensure      => $ensure,
     clients     => $clients,
     mount       => "/var/pesupport/${facts['fqdn']}/etc",
     options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
     nfstag      => 'rsan',
   }
 
-} else {
-    nfs::server::export{ '/var/log/':
-    ensure      => 'absent',
-    mount       => "/var/pesupport/${facts['fqdn']}/log",
-    options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
-    nfstag      => 'rsan',
-  }
-  nfs::server::export{ '/opt/puppetlabs/':
-    ensure      => 'absent',
-    mount       => "/var/pesupport/${facts['fqdn']}/opt",
-    options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
-    nfstag      => 'rsan',
-  }
-  nfs::server::export{ '/etc/puppetlabs/':
-    ensure      => 'absent',
-    mount       => "/var/pesupport/${facts['fqdn']}/etc",
-    options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
-    nfstag      => 'rsan',
-  }
-}
   ######################2. Metrics Dash Board deployment ###############
   # Assuming use of puppet metrics dashboard for telemetry all nodes need
   # include puppet_metrics_dashboard::profile::master::install

--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -12,6 +12,8 @@
 #   The postgres group PE uses the default is pg_user
 # @param [Optional[String]] pg_psql_path
 #   The path to the postgres binary in pe
+# @param [Boolean] nfsmount
+#   Trigger to turn NFS Mounts On Or Off
 # @example
 #   include rsan::exporter
 class rsan::exporter (
@@ -20,15 +22,21 @@ class rsan::exporter (
   Optional[String] $pg_user = 'pe-postgres',
   Optional[String] $pg_group = $pg_user,
   Optional[String] $pg_psql_path = '/opt/puppetlabs/server/bin/psql',
+  Boolean $nfsmount = true,
 ){
 
 ########################1.  Export Logging Function######################
 # Need to determine automatically the Network Fact IP for the RSAN::importer node automatically, applies to all infrastructure nodes
 #########################################################################
 
+
+
   class { '::nfs':
     server_enabled => true
   }
+
+
+if $nfsmount {
 
 # Convert the array of RSAN IP address into an list of clients with options for the NFS export.
 # This reduce will return a string of space deliminated IP addresses with the NFS options.
@@ -63,7 +71,26 @@ class rsan::exporter (
     nfstag      => 'rsan',
   }
 
-
+} else {
+    nfs::server::export{ '/var/log/':
+    ensure      => 'mounted',
+    mount       => "/var/pesupport/${facts['fqdn']}/log",
+    options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
+    nfstag      => 'rsan',
+  }
+  nfs::server::export{ '/opt/puppetlabs/':
+    ensure      => 'mounted',
+    mount       => "/var/pesupport/${facts['fqdn']}/opt",
+    options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
+    nfstag      => 'rsan',
+  }
+  nfs::server::export{ '/etc/puppetlabs/':
+    ensure      => 'mounted',
+    mount       => "/var/pesupport/${facts['fqdn']}/etc",
+    options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
+    nfstag      => 'rsan',
+  }
+}
   ######################2. Metrics Dash Board deployment ###############
   # Assuming use of puppet metrics dashboard for telemetry all nodes need
   # include puppet_metrics_dashboard::profile::master::install

--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -73,19 +73,19 @@ if $nfsmount {
 
 } else {
     nfs::server::export{ '/var/log/':
-    ensure      => 'mounted',
+    ensure      => 'absent',
     mount       => "/var/pesupport/${facts['fqdn']}/log",
     options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
     nfstag      => 'rsan',
   }
   nfs::server::export{ '/opt/puppetlabs/':
-    ensure      => 'mounted',
+    ensure      => 'absent',
     mount       => "/var/pesupport/${facts['fqdn']}/opt",
     options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
     nfstag      => 'rsan',
   }
   nfs::server::export{ '/etc/puppetlabs/':
-    ensure      => 'mounted',
+    ensure      => 'absent',
     mount       => "/var/pesupport/${facts['fqdn']}/etc",
     options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
     nfstag      => 'rsan',

--- a/manifests/remove_exporter.pp
+++ b/manifests/remove_exporter.pp
@@ -6,13 +6,10 @@
 #   include rsan::remove_exporter
 class rsan::remove_exporter {
 
-  #Disable NFS Server and revert config
+  #Disable NFS Server 
 
-  file { '/etc/exports':
-    ensure => absent,
-  }
 
-  service {'nfs':
+  service {'nfs-server':
     ensure => stopped,
   }
 


### PR DESCRIPTION
Prior to this commit the NFS mounts where mandatory 

Following this commit it is possible to set their presence to false, which also removes them from the RSAN node