### PR TITLE
(maint) Fix the release date in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
-## [v0.2.0](https://github.com/puppetlabs/RSAN/tree/v0.2.0) (2021-06-26)
+## [v0.2.0](https://github.com/puppetlabs/RSAN/tree/v0.2.0) (2021-06-28)
 
 [Full Changelog](https://github.com/puppetlabs/RSAN/compare/v0.1.3...v0.2.0)
 


### PR DESCRIPTION
The `0.2.0` release date was previously the 26, however the tags
happened on 28. This commit brings that date in line with the changes in
the repo.