### PR TITLE
Rebrand to Puppet_Operations_appliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
-# rsan
+# Puppet Operations Appliance
 
 #### Table of Contents
 
-- [rsan](#rsan)
+- [Puppet Operations Appliance](#puppet-operations-appliance)
       - [Table of Contents](#table-of-contents)
-  - [RSAN is currently part of a Beta Program](#rsan-is-currently-part-of-a-beta-program)
   - [Description](#description)
   - [Setup](#setup)
-    - [What RSAN modifies in your PE Installation](#what-rsan-modifies-in-your-pe-installation)
+    - [What Puppet_Operations_Appliance modifies in your PE Installation](#what-puppet_operations_appliance-modifies-in-your-pe-installation)
     - [Setup Requirements](#setup-requirements)
       - [Module Dependencies](#module-dependencies)
       - [Minimum Hardware requirements](#minimum-hardware-requirements)
       - [OS Restrictions](#os-restrictions)
-    - [Beginning with rsan](#beginning-with-rsan)
+    - [Beginning with Puppet_Operations_Appliance](#beginning-with-puppet_operations_appliance)
   - [Usage](#usage)
     - [Live Telemetry Display](#live-telemetry-display)
     - [Infrastructure node file and log access](#infrastructure-node-file-and-log-access)
@@ -26,33 +25,18 @@
   - [Contributions](#contributions)
 
 
-## RSAN is currently part of a Beta Program
-
-The Puppet Enterprise Support team is opening an exciting Beta to help us remove some obstacles our customers have reported when engaging the Support Team for incident resolution.
-The Remote Support Service Beta is a combination of a Service provided by the Support team and Puppet Module named RSAN (Remote Support Access Node).
-Puppet Enterprise Support will work with you to see how your organization can access the RSAN deployment and how that process should be implemented. , Currently we have two access options; direct as an incoming VPN connection from the Puppet Support Member, or a simple screen share on the video conferencing software of your choice.
-
-How you can get involved
-
-
-As an existing Puppet Enterprise customer with access to the [Support Portal](http://support.puppet.com), open a Priority 4 ticket with the subject  “Participate in the RSAN beta” and a support engineer will engage with you regarding access methods and any help installing the module you may need.
-
-
 ## Description
 
-The Remote Support Access Node (RSAN) will allow Puppet support engineers to conduct live troubleshooting, resolving problems more quickly and efficiently and lead to a reduction of system disruption to the customer.  
-Customers currently must deliver large volumes of data to support and resolution time is hindered by transfer logistics and privacy concerns. This same data must then be processed by internal support engineers leading to artificially decreased capacity of the support team.
-
-The RSAN platform is designed to be a contained infrastructure endpoint in the customer Puppet Enterprise environment, collating data and access, useful in incident resolution for the target customer deployment.
-The node will allow for read-only access to Puppet Enterprise Component Data and configuration, and limit other access through Puppet Enterprise’s built-in Role Based Access Control(RBAC).
+The Puppet Operations Appliance is designed to be a central point to which a Puppet Enterprise environment may be monitored and maintained.
+The appliance collates data and provides read-only access, useful in incident resolution and preventative maintenance.
 
 
 ## Setup
 
-### What RSAN modifies in your PE Installation 
+### What Puppet_Operations_Appliance modifies in your PE Installation 
 
-RSAN will Export NFS mounts of key directories from each infrastructure node, while also setting up requirements for gathering of metrics and Database access for the RSAN node.
-Software required for the proper functioning of the RSAN will be deployed on the target agent node.
+Puppet_Operations_Appliance will Export NFS mounts of key directories from each Puppet Enterprise infrastructure node, while also setting up requirements for gathering of metrics and database access for the Puppet_Operations_Appliance.
+Open-source software required for the proper functioning of the Puppet_Operations_Appliance will be deployed on the target agent node.
 
 
 ### Setup Requirements 
@@ -66,15 +50,13 @@ Software required for the proper functioning of the RSAN will be deployed on the
 - puppetlabs/stdlib (>= 4.5.0 < 9.0.0)
 - puppetlabs/concat (>= 1.1.2 < 7.0.0)
 - puppetlabs/transition (>= 0.1.0 < 1.0.0)
-- herculesteam/augeasproviders_core (>= 2.1.5 < 4.0.0)
-- herculesteam/augeasproviders_shellvar (>= 1.2.0 < 5.0.0)
+- puppet/augeasproviders_core (>= 2.1.5 < 4.0.0)
+- puppet/augeasproviders_shellvar (>= 1.2.0 < 5.0.0)
 - puppetlabs/apt (>= 2.0.0 < 8.0.0)
 - puppet-grafana (>= 3.0.0 < 11.0.0)
 - puppet-telegraf (>= 2.0.0 < 6.0.0)
 - puppetlabs-apt (>= 4.3.0 < 9.0.0)
 - puppetlabs-inifile (>= 2.0.0 < 5.0.0)
-- puppetlabs-puppetserver_gem (>= 1.1.1 < 3.0.0)
-
 
 #### Minimum Hardware requirements
 
@@ -85,28 +67,28 @@ Software required for the proper functioning of the RSAN will be deployed on the
 
 #### OS Restrictions
 
-RSAN will support RHEL / Debian / Ubuntu however due to the additional of PE Client tools in the installation, you are restricted to installing it on a platform with the same OS as the Primary PE Server.
+Puppet_Operations_Appliance will support RHEL / Debian / Ubuntu however due to the additional of PE Client tools in the installation, you are restricted to installing it on a platform with the same OS as the Primary PE Server.
 
-### Beginning with rsan
+### Beginning with Puppet_Operations_Appliance
 
-RSAN has two main classes for use in the installation:
+Puppet_Operations_Appliance has two main classes for use in the installation:
 
- - rsan::exporter - to be applied to all Puppet infrastructure agents - Console node group "PE Infrastructure Agent"
- - rsan::importer - to be applied to a single node which will be come the Remote Support Access Node(RSAN)
+ - Puppet_Operations_Appliance::exporter - to be applied to all Puppet infrastructure agents - Console node group "PE Infrastructure Agent"
+ - Puppet_Operations_Appliance::importer - to be applied to a single node which will be come the Puppet Operations Appliance.
 
 Following the application of these classes to the infrastructure, Puppet Will need to be run on the corresponding agents in the following order:
 
-Infrastructure Agent(s)->RSAN Agent->Infrastructure Agent(s)->RSAN Agent
+Infrastructure Agent(s)->Puppet_Operations_Appliance Agent->Infrastructure Agent(s)->Puppet_Operations_Appliance Agent
 
 ## Usage
-The following outlines the main features of RSAN and how to consume them
+The following outlines the main features of Puppet_Operations_Appliance and how to consume them
 ### Live Telemetry Display
 
-The Rsan node will host an instance of the [Puppet Operational Dashboard](https://forge.puppet.com/modules/puppetlabs/puppet_operational_dashboards)
+The Puppet_Operations_Appliance node will host an instance of the [Puppet Operational Dashboard](https://forge.puppet.com/modules/puppetlabs/puppet_operational_dashboards)
  
 The Dashboard can be accessed on
 
-**URL:** http://<RSAN-ip\>:3000\
+**URL:** http://<Puppet_Operations_Appliance-ip\>:3000\
 **User:** admin\
 **Password:** admin
 
@@ -114,7 +96,7 @@ For advanced configuration and documentation please see [Puppet Operational Dash
 
 ### Infrastructure node file and log access	
 
-The RSAN node will, by default, mount `/var/log/`, `/opt/puppetlabs` and `/etc/puppetlabs` from each of the Puppet Enterprise Infrastructure nodes on the RSAN platform in the following location, as read-only file systems.
+The Puppet_Operations_Appliance node will, by default, mount `/var/log/`, `/opt/puppetlabs` and `/etc/puppetlabs` from each of the Puppet Enterprise Infrastructure nodes on the Puppet_Operations_Appliance in the following location, as read-only file systems.
 
 `/var/pesupport/<FQDN of Infrastructure node\>/var/log`\
 `/var/pesupport/<FQDN of Infrastructure node\>/opt/puppetlabs`\
@@ -122,12 +104,12 @@ The RSAN node will, by default, mount `/var/log/`, `/opt/puppetlabs` and `/etc/p
 
 #### Optional Configuration
 
-The RSAN Class assumes the RSAN server will mount the shared partitions using the IP address Source designated by the "ipaddress" fact. In any deployment should this assertion not be true, it is necessary to set the following parameter to the source IP address of the RSAN Host:
+The Puppet_Operations_Appliance Class assumes the Puppet_Operations_Appliance server will mount the shared partitions using the IP address Source designated by the "ipaddress" fact. In any deployment should this assertion not be true, it is necessary to set the following parameter to the source IP address of the Puppet_Operations_Appliance Host:
 
 In Hiera 
 
 ```
-rsan::exporter::rsan_importer_ips:
+puppet_operations_appliance::exporter::importer_ips:
   - 1.2.3.4
   ```
 
@@ -137,28 +119,28 @@ Console Class Declaration
 ["1.2.3.4"]
 ```
 
-The RSAN::Exporter class allows for the NFS mounts to be optionally available, to disable existing mounts, or prevent the mounts from installing in the first place set the following parameter:
+The Puppet_Operations_Appliance::Exporter class allows for the NFS mounts to be optionally available, to disable existing mounts, or prevent the mounts from installing in the first place set the following parameter:
 
 
 In Hiera
 
 ```
-rsan::exporter::nfsmount: false
+puppet_operations_appliance::exporter::nfsmount: false
 ```
 
 ### PE Client tools
 
-The RSAN node will deploy Puppet Client tools for use by Puppet Enterprise on the RSAN platform, For More information please see the Puppet Enterprise Documentation:
+The Puppet_Operations_Appliance node will deploy Puppet Client tools for use by Puppet Enterprise on the Puppet_Operations_Appliance platform, For More information please see the Puppet Enterprise Documentation:
 
-[PE Client tools](https://puppet.com/docs/pe/2019.8/installing_pe_client_tools.html)
+[PE Client tools](https://puppet.com/docs/pe/latest/installing_pe_client_tools.html)
 
 A supplementary task is available to generate an RBAC user and role, so that the credentials may be used provided to Puppet Enterprise Support personnel.  
 <br>
 #### Creating Support User  
 <br>
 Run the following task against the Primary Puppet Enterprise Server\
-For information on executing PE tasks see the [Puppet Enterprise Documentation](https://puppet.com/docs/pe/2019.8/tasks_in_pe.html)\
-RSAN::supportuser\
+For information on executing PE tasks see the [Puppet Enterprise Documentation](https://puppet.com/docs/pe/latest/tasks_in_pe.html)\
+Puppet_Operations_Appliance::supportuser\
 When successful the task will return a password, this should be delivered to Puppet Enterprise Support personnel.
 <br>
 <br>
@@ -168,18 +150,18 @@ The Task creates the following user and role:
 
 **User:** pesupport 
 
-**Role:** PE Suport Role 
+**Role:** PE Support Role 
 
-The role is intentionally left without permissions, and should be given only the permissions the installing organisation are authorised to grant to Puppet Enterprise Support personnel. For more information on RBAC permissions please see the [Puppet Enterprise Documentation](https://puppet.com/docs/pe/2019.8/rbac_permissions_intro.html)
+The role is intentionally left without permissions, and should be given only the permissions the installing organisation are authorised to grant to Puppet Enterprise Support personnel. For more information on RBAC permissions please see the [Puppet Enterprise Documentation](https://puppet.com/docs/pe/latest/rbac_permissions_intro.html)
 
 ### Puppet Enterprise Database Access	
 
-The RSAN Platform has a Postgresql client installed, and is granted certificate based access to all Puppet Enterprise Databases on any pe_postgresl node within the current deployment. The access is limited to the [SELECT](https://www.postgresql.org/docs/11/sql-grant.html) privilege and is therefore READONLY in nature.
+The Puppet_Operations_Appliance Platform has a Postgresql client installed, and is granted certificate based access to all Puppet Enterprise Databases on any pe_postgresl node within the current deployment. The access is limited to the [SELECT](https://www.postgresql.org/docs/11/sql-grant.html) privilege and is therefore READONLY in nature.
 
-To use this function execute the following command from the CLI of the RSAN host
+To use this function execute the following command from the CLI of the Puppet_Operations_Appliance host
 
 ```
-psql "host=$(puppet config print server) port=5432 user=rsan sslmode=verify-full sslcert=$(puppet config print hostcert) sslkey=$(puppet config print hostprivkey) sslrootcert=$(puppet config print localcacert) dbname=<pe_db_name>"
+psql "host=$(puppet config print server) port=5432 user=puppet_operations_appliance sslmode=verify-full sslcert=$(puppet config print hostcert) sslkey=$(puppet config print hostprivkey) sslrootcert=$(puppet config print localcacert) dbname=<pe_db_name>"
 ```
 
 Where valid options for <pe_db_name> are:
@@ -193,36 +175,30 @@ Where valid options for <pe_db_name> are:
 
 ## Uninstallation 
 
-To Uninstall RSAN from your Puppet Enterprise Infrastructure.
+To Uninstall Puppet_Operations_Appliance from your Puppet Enterprise Infrastructure.
 
 
  - Remove the following Classification:
-rsan::exporter\
-rsan::importer
+Puppet_Operations_Appliance::exporter\
+Puppet_Operations_Appliance::importer
 
  - Add the following classification to the "PE Infrastructure Agent" node group
- rsan::remove_exporter
+ Puppet_Operations_Appliance::remove_exporter
 
   - Remove the following classification to the "PE Infrastructure Agent" node group
- rsan::remove_exporter
+ Puppet_Operations_Appliance::remove_exporter
 
   - Run Puppet on all nodes in "PE Infrastructure Agent" node group
 
-   - Decommission the RSAN platform 
+   - Decommission the Puppet_Operations_Appliance platform 
 
 
 ## Limitations
- - The RSAN importer class should only be applied one agent node
- - All features are currently enabled and can not be individually disabled, this will be addressed in future releases
- - The current version does not have any built in remote access capability
+ - The Puppet_Operations_Appliance importer class should only be applied one agent node
 
 ## Known Issues
 
- - PuppetDB Metric Collection fails due to CVE-2020-7943  [27](https://github.com/puppetlabs/RSAN/issues/27)
-
-Please refer to the documentation of Puppet Metrics Dashboard for recommended work arounds
-
- - RSAN NFS volumes are mounted RW, but exported RO  [26](https://github.com/puppetlabs/RSAN/issues/26)
+ - Puppet_Operations_Appliance NFS volumes are mounted RW, but exported RO  [26](https://github.com/puppetlabs/Puppet_Operations_Appliance/issues/26)
  
  There is no impact to the end user
 

--- a/functions/get_importer_ips.pp
+++ b/functions/get_importer_ips.pp
@@ -1,12 +1,12 @@
-# @return [Array] List of IP addresses for RSAN nodes or an empty array
-function rsan::get_rsan_importer_ips() {
+# @return [Array] List of IP addresses of the Puppet_operations_appliance(s) or an empty array
+function rsan::get_importer_ips() {
   if $settings::storeconfigs {
-    $rsan_importer_ips =
+    $importer_ips =
     puppetdb_query('facts[value]{
         name = "ipaddress" and
         certname in resources[certname] {
           type = "Class" and
-          title = "Rsan::Importer" and
+          title = "Puppet_operations_appliance::Importer" and
           nodes {
             deactivated is null and
             expired is null
@@ -14,6 +14,6 @@ function rsan::get_rsan_importer_ips() {
           }
         }').map |$data| { $data['value'] }
   } else {
-    $rsan_importer_ips = []
+    $importer_ips = []
   }
 }

--- a/functions/get_importer_ips.pp
+++ b/functions/get_importer_ips.pp
@@ -1,5 +1,5 @@
 # @return [Array] List of IP addresses of the Puppet_operations_appliance(s) or an empty array
-function rsan::get_importer_ips() {
+function puppet_operations_appliance::get_importer_ips() {
   if $settings::storeconfigs {
     $importer_ips =
     puppetdb_query('facts[value]{

--- a/functions/get_postgres_hosts.pp
+++ b/functions/get_postgres_hosts.pp
@@ -1,4 +1,4 @@
-# Function to provide a list of pe_postgresql hosts to RSAN
+# Function to provide a list of pe_postgresql hosts to the puppet_operations_appliance
 # @return [Array] List of FQDN 
 function rsan::get_postgres_hosts() {
   $postgres_hosts =

--- a/functions/get_postgres_hosts.pp
+++ b/functions/get_postgres_hosts.pp
@@ -1,6 +1,6 @@
 # Function to provide a list of pe_postgresql hosts to the puppet_operations_appliance
 # @return [Array] List of FQDN 
-function rsan::get_postgres_hosts() {
+function puppet_operations_appliance::get_postgres_hosts() {
   $postgres_hosts =
   puppetdb_query('resources[certname] {
                     type = "Class" and

--- a/functions/get_puppet_servers.pp
+++ b/functions/get_puppet_servers.pp
@@ -1,6 +1,6 @@
 # Function to return a list of components running pe_puppetserver to puppet_operations_appliance
 # @return [Array] List of Fqdn of nodes with the Master profile
-function rsan::get_puppet_servers() {
+function puppet_operations_appliance::get_puppet_servers() {
   $puppet_servers =
   puppetdb_query('nodes[certname] {
                      resources {

--- a/functions/get_puppet_servers.pp
+++ b/functions/get_puppet_servers.pp
@@ -1,4 +1,4 @@
-# Function to return a list of components running pe_puppetserver to RSAN
+# Function to return a list of components running pe_puppetserver to puppet_operations_appliance
 # @return [Array] List of Fqdn of nodes with the Master profile
 function rsan::get_puppet_servers() {
   $puppet_servers =

--- a/functions/get_puppetdb_hosts.pp
+++ b/functions/get_puppetdb_hosts.pp
@@ -1,5 +1,5 @@
 # @return [Array] List of node running Puppetdb
-function rsan::get_puppetdb_hosts() {
+function puppet_operations_appliance::get_puppetdb_hosts() {
   if $settings::storeconfigs {
     $puppetdb_hosts =
     puppetdb_query('resources[certname] {

--- a/functions/license_uuid.pp
+++ b/functions/license_uuid.pp
@@ -2,9 +2,9 @@
 # If no $content parameter specified, tries to read the license file
 # from /etc/puppetlabs/license.key
 # @param [Optional[String]] content
-#   An array of rsan ip addresses
+#   An array of puppet_operaions appliance ip addresses
 #   Defaults to the output of a PuppetDB query
-function rsan::license_uuid(Optional[String] $content) >> String {
+function puppet_operations_appliance::license_uuid(Optional[String] $content) >> String {
   $license_file_path = '/etc/puppetlabs/license.key'
   if $content {
     $_content = parseyaml($content)

--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -145,7 +145,7 @@ class puppet_operations_appliance::exporter (
           psql_user  => $pg_user,
           psql_group => $pg_group,
           psql_path  => $pg_psql_path,
-          unless     => "SELECT grantee, privilege_type FROM information_schema.role_table_grants WHERE privilege_type = 'SELECT' AND grantee = 'rpuppet_operations_appliance'",
+          unless     => "SELECT grantee, privilege_type FROM information_schema.role_table_grants WHERE privilege_type = 'SELECT' AND grantee = 'puppet_operations_appliance'",
           require    => [
             Class['pe_postgresql::server'],
             Pe_postgresql::Server::Role['puppet_operations_appliance']

--- a/manifests/exporter.pp
+++ b/manifests/exporter.pp
@@ -1,12 +1,12 @@
-# Sets up target nodes with nessary services and access for RSAN
+# Sets up target nodes with nessary services and access for the puppet_operations_appliance
 # When Applied to the Infrastructure Agent Node group, 
 # Will dynamically configure all matching nodes to allow
-#access to key elements of Puppet Enterprise to the RSAN node
-# @param [Array] rsan_importer_ips
-#   An array of rsan ip addresses
+#access to key elements of Puppet Enterprise to the puppet_operations_appliance 
+# @param [Array] importer_ips
+#   An array of importer node ip addresses
 #   Defaults to the output of a PuppetDB query
-# @param [Optional[String]] rsan_host
-#   The certname of the rsan node
+# @param [Optional[String]] appliance_host
+#   The certname of the puppet_operations_appliance 
 # @param [Optional[String]] pg_user
 #   The postgres user PE uses 
 # @param [Optional[String]] pg_group
@@ -22,10 +22,10 @@
 # @param [Optional[Enum]] logdir
 #   Allows the scope of logging to be narrowed
 # @example
-#   include rsan::exporter
-class rsan::exporter (
-  Array $rsan_importer_ips = rsan::get_rsan_importer_ips(),
-  Optional[String] $rsan_host = undef,
+#   include puppet_operations_appliance::exporter
+class puppet_operations_appliance::exporter (
+  Array $importer_ips = puppet_operations_appliance::get_importer_ips(),
+  Optional[String] $appliance_host = undef,
   String $pg_user = 'pe-postgres',
   String $pg_group = $pg_user,
   String $pg_psql_path = '/opt/puppetlabs/server/bin/psql',
@@ -34,10 +34,7 @@ class rsan::exporter (
   Boolean $nfsmount_etc = true,
   Boolean $nfsmount_opt= true,
 ) {
-########################1.  Export Logging Function######################
-# Need to determine automatically the Network Fact IP for the 
-#RSAN::importer node automatically, applies to all infrastructure nodes
-#########################################################################
+  # Setup the NFS Mounts for the appliance
 
   class { 'nfs':
     server_enabled => true,
@@ -58,55 +55,44 @@ class rsan::exporter (
     false => 'absent',
   }
 
-# Convert the array of RSAN IP address into an list of clients with options for the NFS export.
-# This reduce will return a string of space deliminated IP addresses with the NFS options.
-# For example, the output for ['1.2.3.4'] is " 1.2.3.4(ro,insecure,async,no_root_squash)"
-# For example, the output for ['1.2.3.4', '5.6.7.8'] is 
-#   " 1.2.3.4(ro,insecure,async,no_root_squash) 5.6.7.8(ro,insecure,async,no_root_squash)"
-
-  $_rsan_clients = $rsan_importer_ips.reduce('') |$memo, $ip| {
+  $_clients = $importer_ips.reduce('') |$memo, $ip| {
     "${memo} ${ip}(ro,insecure,async,no_root_squash)"
   }
-  $clients = "${_rsan_clients} localhost(ro)"
+  $clients = "${_clients} localhost(ro)"
 
   nfs::server::export { $logdir:
     ensure      => $ensure_log,
     clients     => $clients,
     mount       => "/var/pesupport/${facts['networking']['fqdn']}/log",
     options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
-    nfstag      => 'rsan',
+    nfstag      => 'puppet_operations_appliance',
   }
   nfs::server::export { '/opt/puppetlabs/':
     ensure      => $ensure_opt,
     clients     => $clients,
     mount       => "/var/pesupport/${facts['networking']['fqdn']}/opt",
     options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
-    nfstag      => 'rsan',
+    nfstag      => 'puppet_operations_appliance',
   }
   nfs::server::export { '/etc/puppetlabs/':
     ensure      => $ensure_etc,
     clients     => $clients,
     mount       => "/var/pesupport/${facts['networking']['fqdn']}/etc",
     options_nfs => 'tcp,nolock,rsize=32768,wsize=32768,soft,noatime,actimeo=3,retrans=1',
-    nfstag      => 'rsan',
+    nfstag      => 'puppet_operations_appliance',
   }
 
-  ######################2. Operational dashboards configuration  ###############
+  # Install operational dashboards on PE infrastructure nodes
 
   include puppet_operational_dashboards::enterprise_infrastructure
 
-  #####################3. RSAN postgres command access ######################
-  # Determine if node is pe_postgres host and conditionally apply 
-  # Select Access for the RSAN node cert to all PE databases
-  ######################################################################
-
   if $facts['pe_postgresql_info'] != undef and $facts['pe_postgresql_info']['installed_server_version'] != '' {
-    if $rsan_host {
-      $_rsan_host = $rsan_host
+    if $appliance_host {
+      $_appliance_host = $appliance_host
     } else {
     $_query = puppetdb_query('resources[certname] {
         type = "Class" and
-        title = "Rsan::Importer" and             
+        title = "Puppet_operations_appliance::Importer" and             
         nodes {
           deactivated is null and
           expired is null
@@ -115,16 +101,16 @@ class rsan::exporter (
         limit 1
       }')
       unless $_query.empty {
-        $_rsan_host = $_query[0]['certname']
+        $_appliance_host = $_query[0]['certname']
       }
     }
 
-    # If $rsan_host is not defined and the query fails to find a rsan  host, issue a warning.
+    # If $appliance_host is not defined and the query fails to find an appliance host, issue a warning.
 
-    if $_rsan_host == undef {
-      notify { 'You must specify rsan_host (or apply the rsan class to an agent) to enable access.': }
+    if $_appliance_host == undef {
+      notify { 'You must specify appliance_host (or apply the puppet_operations_appliance class to an agent) to enable access.': }
     } else {
-      pe_postgresql::server::role { 'rsan': }
+      pe_postgresql::server::role { 'puppet_operations_appliance': }
 
       if $facts['pe_postgresql_info']['installed_server_version'] {
         $postgres_version = $facts['pe_postgresql_info']['installed_server_version']
@@ -144,14 +130,14 @@ class rsan::exporter (
       }
 
       $dbs.each |$db| {
-        pe_postgresql::server::database_grant { "CONNECT to rsan for ${db}":
+        pe_postgresql::server::database_grant { "CONNECT to puppet_operations_appliance for ${db}":
           privilege => 'CONNECT',
           db        => $db,
-          role      => 'rsan',
-          require   => Pe_postgresql::Server::Role['rsan'],
+          role      => 'puppet_operations_appliance',
+          require   => Pe_postgresql::Server::Role['puppet_operations_appliance'],
         }
 
-        $grant_cmd = "GRANT SELECT ON ALL TABLES IN SCHEMA \"public\" TO rsan"
+        $grant_cmd = "GRANT SELECT ON ALL TABLES IN SCHEMA \"public\" TO puppet_operations_appliance"
         pe_postgresql_psql { "${grant_cmd} on ${db}":
           command    => $grant_cmd,
           db         => $db,
@@ -159,17 +145,17 @@ class rsan::exporter (
           psql_user  => $pg_user,
           psql_group => $pg_group,
           psql_path  => $pg_psql_path,
-          unless     => "SELECT grantee, privilege_type FROM information_schema.role_table_grants WHERE privilege_type = 'SELECT' AND grantee = 'rsan'",
+          unless     => "SELECT grantee, privilege_type FROM information_schema.role_table_grants WHERE privilege_type = 'SELECT' AND grantee = 'rpuppet_operations_appliance'",
           require    => [
             Class['pe_postgresql::server'],
-            Pe_postgresql::Server::Role['rsan']
+            Pe_postgresql::Server::Role['puppet_operations_appliance']
           ],
         }
 
-        puppet_enterprise::pg::cert_allowlist_entry { "allow-rsan-access for ${db}":
-          user                          => 'rsan',
+        puppet_enterprise::pg::cert_allowlist_entry { "allow-puppet_operations_appliance-access for ${db}":
+          user                          => 'puppet_operations_appliance',
           database                      => $db,
-          allowed_client_certname       => $_rsan_host,
+          allowed_client_certname       => $_appliance_host,
           pg_ident_conf_path            => "/opt/puppetlabs/server/data/postgresql/${postgres_version}/data/pg_ident.conf",
           ip_mask_allow_all_users_ssl   => '0.0.0.0/0',
           ipv6_mask_allow_all_users_ssl => '::/0',

--- a/manifests/importer.pp
+++ b/manifests/importer.pp
@@ -1,19 +1,15 @@
 # Class to consume the resources provided by the exporter class.
-# when applied to a node, all tooling agttributed to RSAN will be set up
+# when applied to a node, all tooling agttributed to puppet_operations_appliance will be set up
 # @example
-#   include rsan::importer
-class rsan::importer {
-  ##################### 1.Import logging from the exporter groups #####################
-  # depending on the method, could be import exported respore with rsan tag
-  #####################################################################################
-
+#   include puppet_operations_appliance::importer
+class puppet_operations_appliance::importer {
+  # Import the logs by mounting the NFS mountpoints from the exporter nodes
   class { 'nfs':
     client_enabled => true,
   }
-  Nfs::Client::Mount <<| nfstag == 'rsan' |>>
+  Nfs::Client::Mount <<| nfstag == 'puppet_operations_appliance' |>>
 
-  #################### 2. Deploy Client tools, and deploy PSL client #################
-  ####################################################################################
+  # Deploy Client tools, and deploy PSL client
 
   include postgresql::client
   include puppet_enterprise::profile::controller
@@ -26,7 +22,7 @@ class rsan::importer {
     value   => '$privatekeydir/$certname.pem{mode = 0600}',
   }
 
-  ################### 3. Operational dashboards deployment ########################################
+  # Operational dashboards deployment 
 
   include puppet_operational_dashboards
 }

--- a/manifests/remove_exporter.pp
+++ b/manifests/remove_exporter.pp
@@ -1,11 +1,11 @@
 # @summary disables and removes services and components enabled by the exporter class
 #
-# In the event RSAN should be uninstalled on all or some of the exporter nodes,
+# In the event puppet_operations_appliance should be uninstalled on all or some of the exporter nodes,
 # this will stop NFS service, and remove the database components if applied to a postgres node
 #
 # @example
-#   include rsan::remove_exporter
-class rsan::remove_exporter {
+#   include rpuppet_operations_appliance::remove_exporter
+class puppet_operations_appliance::remove_exporter {
   #Disable NFS Server 
 
   service { 'nfs-server':
@@ -15,7 +15,7 @@ class rsan::remove_exporter {
   if $facts['pe_postgresql_info'] != undef and $facts['pe_postgresql_info']['installed_server_version'] != '' {
     $dbs = ['pe-activity', 'pe-classifier', 'pe-inventory', 'pe-puppetdb', 'pe-rbac', 'pe-orchestrator']
     $dbs.each |$db| {
-      $dropowned_cmd = 'DROP OWNED BY rsan'
+      $dropowned_cmd = 'DROP OWNED BY puppet_operations_appliance'
       pe_postgresql_psql { "${dropowned_cmd} on ${db}":
         command    => $dropowned_cmd,
         db         => $db,
@@ -27,7 +27,7 @@ class rsan::remove_exporter {
       }
     }
 
-    $droprole_cmd = 'DROP ROLE rsan'
+    $droprole_cmd = 'DROP ROLE puppet_operations_appliance'
     pe_postgresql_psql { "${droprole_cmd}  ":
       command    => $droprole_cmd,
       db         => pe-puppetdb,
@@ -35,7 +35,7 @@ class rsan::remove_exporter {
       psql_user  => $pe_postgresql::server::user,
       psql_group => $pe_postgresql::server::group,
       psql_path  => $pe_postgresql::server::psql_path,
-      require    => Pe_postgresql_psql['DROP OWNED BY rsan on pe-puppetdb'],
+      require    => Pe_postgresql_psql['DROP OWNED BY puppet_operations_appliance on pe-puppetdb'],
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,8 +1,8 @@
 {
-  "name": "puppetlabs-rsan",
+  "name": "puppetlabs-puppet_operations_appliance",
   "version": "0.3.0",
   "author": "Martin Ewings",
-  "summary": "Module to Configure Remote Support Access Node for Puppet Enterprise",
+  "summary": "Configures an operations applicance for monitoring and maintaining a PE installation",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/RSAN",
   "project_page": "https://github.com/puppetlabs/RSAN",

--- a/spec/classes/exporter_spec.rb
+++ b/spec/classes/exporter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'rsan::exporter' do
+describe 'puppet_operations_appliance::exporter' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }

--- a/spec/classes/importer_spec.rb
+++ b/spec/classes/importer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'rsan::importer' do
+describe 'puppet_operations_appliance::importer' do
   before :each do
     Puppet::Parser::Functions.newfunction(:puppetdb_query, type: :rvalue, arity: 1) do |_args|
       []

--- a/spec/classes/remove_exporter_spec.rb
+++ b/spec/classes/remove_exporter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'rsan::remove_exporter' do
+describe 'puppet_operations_appliance::remove_exporter' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }

--- a/spec/functions/license_uuid_spec.rb
+++ b/spec/functions/license_uuid_spec.rb
@@ -16,6 +16,6 @@ license = <<-LICENSE
   #####################
 LICENSE
 
-describe 'rsan::license_uuid' do
+describe 'puppet_operations_appliance::license_uuid' do
   it { is_expected.to run.with_params(license).and_return('0000111122223333444455556666777788889999') }
 end


### PR DESCRIPTION
Prior to this commit the Module was called RSAN, which was an acroynm for Remote support access node.

This Module has use outside of this function as one stop location for maintenance and logging so the new name reflects the function.

This version also now uses Puppet Operational Dashboards instead of its predecessor puppet metrics dashboards